### PR TITLE
Dropped a RegExp in favour of an .endsWith

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ export default function(file, acceptedFiles) {
       const validType = type.trim()
       if (validType.charAt(0) === '.') {
         return fileName.toLowerCase().endsWith(validType.toLowerCase())
-      } else if (/\/\*$/.test(validType)) {
+      } else if (validType.endsWith('/*')) {
         // This is something like a image/* mime type
         return baseMimeType === validType.replace(/\/.*$/, '')
       }


### PR DESCRIPTION
I personally feel this makes the code slightly easier to read. `.endsWith` is already used the line immediately above the changed one. Therefore, I see no reason not to use it.

Perhaps there's a performance benefit as well, I don't know.